### PR TITLE
block client.coffee

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -45,6 +45,7 @@ blockChats:
 - ^\/?(?:essentials:)?e?kill \*
 - '^\/?(?:essentials:)?e?(bc|bcast|broadcast|shout) (.*\\n){4,}'
 - '^\/?(?:minecraft:)?deop @a'
+- '.*client.coffee.*'
 # regex blocked usernames
 blockUsernames:
   - "\\d{10}"


### PR DESCRIPTION
Recently, 0skar (supposedly) has been advertising 0x150's cheat client Coffee on ayunboom. I am aware that the SRC is public on github, but its the moles and they have a history of hiding sussy wussy code in things (hint hint shadow client)